### PR TITLE
Allow to set region via params

### DIFF
--- a/lib/ueberauth/strategy/bnet.ex
+++ b/lib/ueberauth/strategy/bnet.ex
@@ -132,7 +132,6 @@ defmodule Ueberauth.Strategy.Bnet do
   end
 
   defp get_region("EU" <> _code), do: "eu"
-  defp get_region("KR" <> _code), do: "kr"
-  defp get_region("TW" <> _code), do: "tw"
+  defp get_region("KR" <> _code), do: "apac"
   defp get_region(_code), do: "us"
 end

--- a/lib/ueberauth/strategy/bnet.ex
+++ b/lib/ueberauth/strategy/bnet.ex
@@ -14,6 +14,13 @@ defmodule Ueberauth.Strategy.Bnet do
         opts
       end
 
+    opts =
+      if conn.params["region"] do
+        Keyword.put(opts, :region, conn.params["region"])
+      else
+        opts
+      end
+
     opts = Keyword.put(opts, :redirect_uri, callback_url(conn))
     redirect!(conn, Ueberauth.Strategy.Bnet.OAuth.authorize_url!(opts))
   end
@@ -21,8 +28,14 @@ defmodule Ueberauth.Strategy.Bnet do
   @doc false
   def handle_callback!(%Plug.Conn{params: %{"code" => code}} = conn) do
     # opts = [redirect_uri: callback_url(conn)]
+    region = get_region(code)
+
     client =
-      Ueberauth.Strategy.Bnet.OAuth.get_token!(code: code, redirect_uri: callback_url(conn))
+      Ueberauth.Strategy.Bnet.OAuth.get_token!(
+        [code: code, redirect_uri: callback_url(conn)],
+        [],
+        region: region
+      )
 
     if client.token.access_token == nil do
       err = client.token.other_params["error"]
@@ -117,4 +130,9 @@ defmodule Ueberauth.Strategy.Bnet do
       }
     }
   end
+
+  defp get_region("EU" <> _code), do: "eu"
+  defp get_region("KR" <> _code), do: "kr"
+  defp get_region("TW" <> _code), do: "tw"
+  defp get_region(_code), do: "us"
 end


### PR DESCRIPTION
I had an issue where I need to support multiple regions in an app and I couldn't get [dynamic provider configuration](https://github.com/ueberauth/ueberauth/pull/107) implemented in ueberauth quite working.

This PR adds two features:

When `region` is added to the request URL, it will use it when requesting the code from the BNet API.

When the code is returned, infer the region based on the first two characters.
Wasn't too sure about it, as it overrides the configuration but I couldn't think of a nice way of passing along the region from the request.

What do you think?